### PR TITLE
Composer reports unresolved dependencies on mink-goutte-driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,14 @@
         "behat/mink-extension":  "*",
 
         "behat/mink-goutte-driver":     "*",
-        "behat/mink-selenium2-driver":  "*"
+        "behat/mink-selenium2-driver":  "*",
+
+        "fabpot/goutte": "1.0.x-dev",
+        "symfony/browser-kit": "2.1.*@dev",
+        "symfony/dom-crawler": "2.1.*@dev",
+        "symfony/css-selector": "2.1.*@dev",
+        "symfony/finder": "2.1.*@dev",
+        "symfony/process": "2.1.*@dev"
     },
 
     "config": {


### PR DESCRIPTION
Installing mink-goutte-driver used to lead to "unresolved dependency" messages. This is because the version of Goutte (fabpot/goutte) on Packagist requires several @dev channel packages. Changes to composer.json prevent the error messages by requesting the required packages directly.

Maybe there's a better way than just asking for the extra packages, but this worked for me.
