### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,10 @@
     "require": {
         "behat/behat":           "2.4@stable",
         "behat/mink-extension":  "*",
-
         "behat/mink-goutte-driver":     "*",
         "behat/mink-selenium2-driver":  "*"
     },
-
+    "minimum-stability": "dev",
     "config": {
         "bin-dir": "bin"
     }


### PR DESCRIPTION
Dependency update as "minimum-stability" key is now required
I added composer.lock as getcomposer.org recommends it.

Romain
